### PR TITLE
add introspection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ For example, if all schemas are located in `src/schemas/`, the setting here woul
 ### `securePort: number`
 
 Specify a secure port for the Apollo server. Defaults to the HarperDB default secure port.
+
+### `introspection: boolean`
+
+Enable/disable GraphQL introspection

--- a/extension.js
+++ b/extension.js
@@ -53,6 +53,7 @@ export function start(options = {}) {
 		schemas: options.schemas ?? './schemas.graphql',
 		securePort: options.securePort,
 		plugins: options.plugins,
+		introspection: options.introspection ?? process.env.NODE_ENV !== 'production',
 	};
 
 	logger.debug('@harperdb/apollo extension configuration:\n' + JSON.stringify(config, null, 2));
@@ -78,7 +79,7 @@ export function start(options = {}) {
 			let plugins;
 			if (config.plugins) {
 				const pluginsPath = join(componentPath, config.plugins);
-				 ({ default: plugins } = await import(pathToFileURL(pluginsPath)));
+				({ default: plugins } = await import(pathToFileURL(pluginsPath)));
 			}
 
 			// Set up Apollo Server
@@ -86,7 +87,8 @@ export function start(options = {}) {
 				typeDefs,
 				resolvers: resolvers.default || resolvers,
 				cache: new Cache(),
-				plugins
+				plugins,
+				introspection: config.introspection
 			});
 
 			await apollo.start();

--- a/extension.js
+++ b/extension.js
@@ -53,7 +53,7 @@ export function start(options = {}) {
 		schemas: options.schemas ?? './schemas.graphql',
 		securePort: options.securePort,
 		plugins: options.plugins,
-		introspection: options.introspection ?? process.env.NODE_ENV !== 'production',
+		introspection: options.introspection,
 	};
 
 	logger.debug('@harperdb/apollo extension configuration:\n' + JSON.stringify(config, null, 2));


### PR DESCRIPTION
Adds support for the introspection option. This is [enabled internally by default when NODE_ENV is production](https://www.apollographql.com/docs/apollo-server/api/apollo-server#:~:text=The%20default%20value%20is%20true%2C%20unless%20the%20NODE_ENV%20environment%20variable%20is%20set%20to%20production.), but this we also explicitly do it here (by default).